### PR TITLE
tests for extracted analysis_pipeline.py

### DIFF
--- a/app/backend/tests_backend/test_analysis_pipeline.py
+++ b/app/backend/tests_backend/test_analysis_pipeline.py
@@ -1,0 +1,43 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from anytree import Node
+from analysis_pipeline import AnalysisPipeline
+
+@pytest.fixture
+def pipeline():
+    #mock the dependencies
+    return AnalysisPipeline(MagicMock(), MagicMock(), MagicMock())
+
+def test_data_helpers(pipeline):
+    """Tests if the pipeline can correctly fetch and convert binary data"""
+    pipeline.file_data_list = [b"Hello World"]
+    assert pipeline.get_bin_data_by_Id(0) == b"Hello World"
+    assert pipeline.binary_to_str([b"test"]) == ["test"]
+
+@patch("analysis_pipeline.FileManager")
+def test_file_load_failure(mock_fm, pipeline):
+    """Tests that the pipeline stops if the file fails to load"""
+    #forcing hte file manager to return error
+    mock_fm.return_value.load_from_filepath.return_value = {"status": "error", "message": "fail"}
+    pipeline.run_analysis("fake_path")
+    pipeline.cli.print_status.assert_any_call("Load Error: fail", "error")
+
+@patch("analysis_pipeline.FileManager")
+@patch("analysis_pipeline.TreeProcessor")
+@patch("analysis_pipeline.LocalLLMClient")
+
+def test_successful_save(mock_llm, mock_tp, mock_fm, pipeline):
+    """Tests that the pipeline actually triggers a database save on success"""
+    #success event 
+    mock_fm.return_value.load_from_filepath.return_value = {
+        "status": "success", 
+        "tree": Node("root"), 
+        "binary_data": []
+    }
+
+    #create fake results
+    mock_llm.return_value.generate_summary.return_value = "Summary"
+    pipeline.run_analysis("valid_path")
+
+    assert pipeline.database_manager.create_new_result.called #check if asked db for new entry
+    assert pipeline.database_manager.save_resume_points.called #check that summary was sent to be saved


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

> Please include a summary of the change and which issue is fixed.  
> Include relevant motivation and context.  
> List any dependencies that are required for this change.

Implemented testing for the `analysis_pipeline.py`:
- The tests confirm that the analysis pipeline handles binary correctly, handles file reading errors and also simulates successful analysis run (creates unique result in database, generates project summary and sends summary to the database).

**Closes:** #274

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

- [x] `test_data_helpers()`
- [x] `test_file_load_failure()`
- [x] `test_successful_save()`

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
