### PR TITLE
adjust presidio config to prevent spacy download on first exec

### DIFF
--- a/app/backend/pii_remover.py
+++ b/app/backend/pii_remover.py
@@ -3,7 +3,25 @@ from nltk.tokenize import word_tokenize
 from typing import List
 import re
 from presidio_analyzer import AnalyzerEngine
+from presidio_analyzer.nlp_engine import NlpEngine, SpacyNlpEngine, NerModelConfiguration
 
+def init_anonymizer():
+     # Define which model to use
+    model_config = [{"lang_code": "en", "model_name": "en_core_web_sm"}]
+
+    # Define which entities the model returns and how they map to Presidio's
+    entity_mapping = dict(
+        PER="PERSON",
+        LOC= "LOCATION",
+        GPE="LOCATION",
+        ORG="ORGANIZATION"
+    )
+
+    ner_model_configuration = NerModelConfiguration(default_score = 0.6, model_to_presidio_entity_mapping=entity_mapping)
+
+    # Create the NLP Engine based on this configuration
+    spacy_nlp_engine = SpacyNlpEngine(models= model_config, ner_model_configuration=ner_model_configuration)
+    return spacy_nlp_engine
 
 def remove_pii(processed_docs: List[List[str]]) -> List[List[str]]:
     """ Takes a list of tokens lists (processed text and code documents) and removes PII using Presidio.
@@ -12,8 +30,9 @@ def remove_pii(processed_docs: List[List[str]]) -> List[List[str]]:
     """
     MAX_CHARS = 200_000
 
-    # Simple initialization like the working version - let Presidio handle the model loading
-    analyzer = AnalyzerEngine()
+    spacy_nlp_engine = init_anonymizer()
+    
+    analyzer = AnalyzerEngine(nlp_engine=spacy_nlp_engine)
     anonymizer = AnonymizerEngine()
 
     bag_of_words: List[List[str]] = []


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

> Please include a summary of the change and which issue is fixed.  
> Include relevant motivation and context.  
> List any dependencies that are required for this change.

**Closes:** #371  (issue number)

Manually define and use ML model configs for the PII remover to use the spacy_sm model that is downloaded during the build process.
This avoids the 400mb download that happens in container in app during the first execution
It also drastically speeds up the text preprocessing step , sacrificing quality instead.

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [x] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

- All previous pii removal tests still pass.
- Manually checked automatic download did not occur after build

---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>
<img width="496" height="322" alt="image" src="https://github.com/user-attachments/assets/638b5335-f634-4f0e-b4e1-43c5652fbeda" />

<!-- Add your screenshots here -->

</details>
