### PR TITLE
move constraint from table defined to manual addition

### DIFF
--- a/app/database/initdb.sql
+++ b/app/database/initdb.sql
@@ -13,7 +13,7 @@ Filesets(
     analysis_id uuid REFERENCES Analyses(analysis_id) NOT NULL UNIQUE,
     file_data bytea, -- Only the most recent set of binary data for the files is maintained. 
                     --But multiple trees can be maintained for the same analysis in Filetrees table
-    file_data_tree_id integer REFERENCES Filetrees(filetree_id) DEFAULT NULL -- points to the most recent tree
+    file_data_tree_id integer
 );
 
 CREATE TABLE IF NOT EXISTS
@@ -65,6 +65,10 @@ Portfolios(
 
     
 );
+
+ALTER TABLE Filesets
+ADD CONSTRAINT latest_filetree_tracking
+FOREIGN KEY (file_data_tree_id) REFERENCES Filetrees(filetree_id);
 
 CREATE DATABASE test_db 
 WITH TEMPLATE "user";


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

All details same as PR #342 .

Fixes issues on some user's local systems where table creation fails.
The reciprocal fk between filesets and filetrees can cause issues for SOME sql parsers.
Moved fkey handling to alter table statement

Closes #384 