### PR TITLE
Resume Preview and Export

### DIFF
--- a/app/frontend/capstone-project-frontend/package.json
+++ b/app/frontend/capstone-project-frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.1",
+    "docx": "^9.6.1",
     "jszip": "^3.10.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/app/frontend/capstone-project-frontend/src/App.tsx
+++ b/app/frontend/capstone-project-frontend/src/App.tsx
@@ -136,6 +136,8 @@ function App() {
               resumeId={viewResumeId}
               onPrevious={() => setCurrentStep(4)} 
               onComplete={() => setCurrentStep(6)} 
+              githubUsername={onboardingData?.githubUsername ?? ""}
+              userEmail={onboardingData?.email ?? ""}
             /> 
           )}
           

--- a/app/frontend/capstone-project-frontend/src/components/resumePreviewModal.tsx
+++ b/app/frontend/capstone-project-frontend/src/components/resumePreviewModal.tsx
@@ -1,0 +1,214 @@
+import { useRef, useState } from "react";
+import type { Resume } from "../types/resumeTypes";
+import { downloadDocx, downloadPdf } from "../utils/resumeExports";
+
+// ─── Preview primitives ───────────────────────────────────────────────────────
+
+function SectionHead({ title }: { title: string }) {
+  return (
+    <div className="mt-3 mb-1">
+      <p className="text-[10px] font-bold tracking-[0.1em] uppercase text-[#0f1629]">{title}</p>
+      <div className="border-b border-[#0f1629] mb-1" />
+    </div>
+  );
+}
+
+function TwoCol({ left, right, leftBold = false }: { left: string; right: string; leftBold?: boolean }) {
+  return (
+    <div className="flex justify-between items-baseline gap-2 mb-0.5">
+      <span className={`text-[11px] text-[#0f1629] ${leftBold ? "font-bold" : "font-normal"}`}>{left}</span>
+      <span className="text-[10px] text-[#6b7280] shrink-0">{right}</span>
+    </div>
+  );
+}
+
+function Bullet({ text }: { text: string }) {
+  return (
+    <div className="flex gap-1.5 mb-0.5">
+      <span className="text-[11px] text-[#0f1629] shrink-0 mt-px">•</span>
+      <span className="text-[11px] text-[#0f1629] leading-snug">{text}</span>
+    </div>
+  );
+}
+
+function Sub({ text, italic = false }: { text: string; italic?: boolean }) {
+  return (
+    <p className={`text-[11px] text-[#64748b] mb-0.5 ${italic ? "italic" : ""}`}>{text}</p>
+  );
+}
+
+// ─── Section components ───────────────────────────────────────────────────────
+
+function PreviewContact({ r }: { r: Resume }) {
+  const parts = [
+    r.user_email,
+    r.github_username && `github.com/${r.github_username}`,
+    r.phone,
+    r.linkedin,
+  ].filter(Boolean);
+
+  return (
+    <div className="text-center mb-3">
+      <p className="text-[18px] font-bold tracking-tight text-[#0f1629] mb-0.5">
+        {r.full_name || r.github_username || "Resume"}
+      </p>
+      <p className="text-[10px] text-[#6b7280]">{parts.join("  |  ")}</p>
+    </div>
+  );
+}
+
+function PreviewSummary({ summary }: { summary: string[] }) {
+  if (!summary.length) return null;
+  return (
+    <>
+      <SectionHead title="Summary" />
+      {summary.map((s, i) => <Bullet key={i} text={s} />)}
+      <div className="mb-2" />
+    </>
+  );
+}
+
+function PreviewWork({ work }: { work: Resume["work_experience"] }) {
+  if (!work.length) return null;
+  return (
+    <>
+      <SectionHead title="Work Experience" />
+      {work.map((w, i) => (
+        <div key={i} className="mb-2">
+          <TwoCol left={`${w.role} — ${w.company}`} right={w.date_range} leftBold />
+          {w.location && <Sub text={w.location} italic />}
+          {w.description.map((d, j) => <Bullet key={j} text={d} />)}
+        </div>
+      ))}
+    </>
+  );
+}
+
+function PreviewEducation({ education }: { education: Resume["education"] }) {
+  if (!education.length) return null;
+  return (
+    <>
+      <SectionHead title="Education" />
+      {education.map((e, i) => (
+        <div key={i} className="mb-2">
+          <TwoCol left={e.institution} right={e.date_range} leftBold />
+          <Sub text={[e.degree, e.major && `Major in ${e.major}`, e.minor && `Minor in ${e.minor}`].filter(Boolean).join(" · ")} />
+          {e.notes && <Sub text={e.notes} italic />}
+        </div>
+      ))}
+    </>
+  );
+}
+
+function PreviewProjects({ projects }: { projects: Resume["projects"] }) {
+  if (!projects.length) return null;
+  return (
+    <>
+      <SectionHead title="Projects" />
+      {projects.map((p, i) => (
+        <div key={i} className="mb-2">
+          <TwoCol left={p.name} right={p.date_range} leftBold />
+          {p.frameworks.length > 0 && <Sub text={`Technologies: ${p.frameworks.join(", ")}`} />}
+          <Bullet text={p.collaboration} />
+        </div>
+      ))}
+    </>
+  );
+}
+
+function PreviewAwards({ awards }: { awards: Resume["awards"] }) {
+  if (!awards.length) return null;
+  return (
+    <>
+      <SectionHead title="Awards & Honours" />
+      {awards.map((a, i) => (
+        <div key={i} className="mb-2">
+          <TwoCol left={`${a.title} — ${a.issuer}`} right={a.date} leftBold />
+          {a.description.map((d, j) => <Bullet key={j} text={d} />)}
+        </div>
+      ))}
+    </>
+  );
+}
+
+function PreviewSkills({ skills }: { skills: string[] }) {
+  if (!skills.length) return null;
+  return (
+    <>
+      <SectionHead title="Skills" />
+      <p className="text-[11px] text-[#0f1629] mb-2">{skills.join("  ·  ")}</p>
+    </>
+  );
+}
+
+function PreviewLanguages({ languages }: { languages: Resume["languages"] }) {
+  if (!languages.length) return null;
+  return (
+    <>
+      <SectionHead title="Programming Languages" />
+      <p className="text-[11px] text-[#0f1629] mb-2">{languages.map(l => l.name).join("  ·  ")}</p>
+    </>
+  );
+}
+
+// ─── Modal ────────────────────────────────────────────────────────────────────
+
+export default function ResumePreviewModal({ resume, onClose }: { resume: Resume; onClose: () => void }) {
+  const previewRef = useRef<HTMLDivElement>(null);
+  const [busy, setBusy] = useState<"docx" | "pdf" | null>(null);
+
+  const handleDocx = async () => {
+    setBusy("docx");
+    try   { await downloadDocx(resume); }
+    catch (e) {console.error("Failed to download DOCX:", e); alert("Sorry, something went wrong while generating the DOCX file.");}
+    finally { setBusy(null); }
+  };
+
+  const handlePdf = () => {
+    if (!previewRef.current) return;
+    setBusy("pdf");
+    downloadPdf(previewRef.current);
+    setBusy(null);
+  };
+
+  return (
+    <div onClick={onClose} className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 overflow-y-auto py-10">
+      <div onClick={e => e.stopPropagation()} className="flex flex-col items-center gap-4 w-max">
+
+        {/* Toolbar */}
+        <div className="flex items-center justify-between gap-3 w-full bg-white rounded-xl shadow-md px-5 py-3">
+          <p className="text-[11px] font-bold tracking-[0.1em] uppercase text-[#6b7280]">Resume Preview</p>
+          <div className="flex items-center gap-2">
+            <button onClick={handleDocx} disabled={busy !== null}
+              className="text-xs font-bold text-white bg-[#6378ff] rounded-lg px-4 py-1.5 hover:bg-indigo-700 transition-all disabled:opacity-50">
+              {busy === "docx" ? "Generating…" : "Download DOCX"}
+            </button>
+            <button onClick={handlePdf} disabled={busy !== null}
+              className="text-xs font-bold text-white bg-[#0f1629] rounded-lg px-4 py-1.5 hover:bg-slate-800 transition-all disabled:opacity-50">
+              {busy === "pdf" ? "Generating…" : "Download PDF"}
+            </button>
+            <button onClick={onClose}
+              className="text-xs font-semibold text-[#64748b] border border-[#eef0f6] rounded-lg px-3 py-1.5 hover:bg-[#eef0f6] transition-all">
+              Close
+            </button>
+          </div>
+        </div>
+
+        {/* Paper */}
+        <div ref={previewRef} className="shadow-2xl rounded-sm bg-white w-[816px] min-h-[1056px] px-12 py-9">
+          <div>
+            <PreviewContact r={resume} />
+            <PreviewSummary summary={resume.summary} />
+            <PreviewWork work={resume.work_experience} />
+            <PreviewEducation education={resume.education} />
+            <PreviewProjects projects={resume.projects} />
+            <PreviewAwards awards={resume.awards} />
+            <PreviewSkills skills={resume.skills} />
+            <PreviewLanguages languages={resume.languages} />
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/capstone-project-frontend/src/pages/resume_display.tsx
+++ b/app/frontend/capstone-project-frontend/src/pages/resume_display.tsx
@@ -1,14 +1,17 @@
 import { useState, useEffect } from "react";
 import SectionCard from "../components/SectionCard";
 import type { Resume, Project, Language, EducationEntry, WorkEntry, AwardEntry } from "../types/resumeTypes";
-
+import ResumePreviewModal from "../components/resumePreviewModal";
 // ─── Mock data ────────────────────────────────────────────────────────────────
 
 export const mockResume: Resume = {
   analysis_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
   // TODO (backend): pass github_username and user_email through _build_resume()
+  full_name: "John Doe",
   github_username: "yourusername",
   user_email: "you@example.com",
+  phone: "123-456-7890",
+  linkedin: "linkedin.com/in/yourusername",
   summary: [
     "Full-stack developer with experience building collaborative web and mobile applications. Strong version control practices and a focus on clean, maintainable code.",
     "Passionate about learning new technologies and applying them to solve real-world problems. Seeking opportunities to contribute to impactful projects and grow as a software engineer.",
@@ -75,7 +78,7 @@ export const mockResume: Resume = {
 // ─── API ───────────────────────────────────────────────────────────────
 const API_BASE = "http://localhost:8080";
 
-async function fetchResume(resumeId: string): Promise<Resume> {
+async function fetchResume(resumeId: string, githubUsername: string, userEmail: string): Promise<Resume> {
   const res = await fetch(`${API_BASE}/resume/${resumeId}`);
   if (!res.ok) throw new Error(`Failed to fetch resume: ${res.status} ${res.statusText}`);
   const data = await res.json();
@@ -92,8 +95,11 @@ async function fetchResume(resumeId: string): Promise<Resume> {
     projects: Array.isArray(r.projects) ? r.projects : [],
     skills: Array.isArray(r.skills) ? r.skills : [],
     languages: Array.isArray(r.languages) ? r.languages : [],
-    github_username: r.github_username ?? "",
-    user_email: r.user_email ?? "",
+    full_name: r.full_name ?? "",
+    github_username: r.github_username || githubUsername,
+    user_email: r.user_email || userEmail,
+    phone: r.phone ?? "",
+    linkedin: r.linkedin ?? "",
   };
 }
 
@@ -197,27 +203,33 @@ function BulletEditor({ bullets, onChange }: { bullets: string[]; onChange: (b: 
 }
 // ─── Contact ──────────────────────────────────────────────────────────────────
 
-function ContactSection({ github_username, user_email, onChange }: {
-  github_username: string; user_email: string; onChange: (u: string, e: string) => void;
+function ContactSection({ full_name, github_username, user_email, phone, linkedin, onChange }: {
+  full_name: string; github_username: string; user_email: string; phone: string; linkedin: string; onChange: (fn: string, u: string, e: string, p: string, l: string) => void;
 }) {
-  const { editing, draft, setDraft, open, cancel, close } = useEditState({ github_username, user_email });
+  const { editing, draft, setDraft, open, cancel, close } = useEditState({ full_name, github_username, user_email, phone, linkedin });
   return (
     <SectionCard title="Contact" icon="👤">
       <div className="flex items-start justify-between gap-4">
         <div className="flex-1 space-y-2">
           {editing ? (
             <>
+              <Field value={draft.full_name}       onChange={v => setDraft(d => ({ ...d, full_name: v }))} placeholder="Full Name" />
               <Field value={draft.github_username} onChange={v => setDraft(d => ({ ...d, github_username: v }))} placeholder="GitHub username" />
               <Field value={draft.user_email}      onChange={v => setDraft(d => ({ ...d, user_email: v }))}      placeholder="Email address" />
+              <Field value={draft.phone}           onChange={v => setDraft(d => ({ ...d, phone: v }))}           placeholder="Phone number" />
+              <Field value={draft.linkedin}        onChange={v => setDraft(d => ({ ...d, linkedin: v }))}        placeholder="LinkedIn profile" />
             </>
           ) : (
             <>
-              <p className="text-sm font-semibold text-slate-700">{github_username}</p>
+              <p className="text-sm font-semibold text-slate-700">{full_name}</p>
+              {github_username && <p className="text-sm text-slate-500">github.com/{github_username}</p>}
               <p className="text-sm text-slate-500">{user_email}</p>
+              <p className="text-sm text-slate-500">{phone}</p>
+              <p className="text-sm text-slate-500">{linkedin}</p>
             </>
           )}
         </div>
-        <EditControls editing={editing} onEdit={open} onSave={() => { onChange(draft.github_username, draft.user_email); close(); }} onCancel={cancel} />
+        <EditControls editing={editing} onEdit={open} onSave={() => { onChange(draft.full_name, draft.github_username, draft.user_email, draft.phone, draft.linkedin); close(); }} onCancel={cancel} />
       </div>
     </SectionCard>
   );
@@ -585,46 +597,41 @@ function LanguagesSection({ languages, onChange }: { languages: Language[]; onCh
   );
 }
 
-// ─── Download placeholder ─────────────────────────────────────────────────────
-// TODO (frontend): implement export using the `docx` npm package — no backend changes needed
-
-function DownloadButton() {
-  const [showTip, setShowTip] = useState(false);
+// ─── Preview/Download placeholder ─────────────────────────────────────────────────────
+function PreviewButton({ resume }: { resume: Resume }) {
+  const [open, setOpen] = useState(false);
   return (
-    <div className="relative inline-block">
-      <button disabled onMouseEnter={() => setShowTip(true)} onMouseLeave={() => setShowTip(false)}
-        className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold border bg-white text-slate-400 border-slate-200 cursor-not-allowed opacity-60">
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold bg-[#6378ff] text-white hover:bg-indigo-700 transition-all shadow-sm"
+      >
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
           <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><polyline points="7 10 12 15 17 10" /><line x1="12" y1="15" x2="12" y2="3" />
         </svg>
         Download Resume
-        <span className="text-xs font-bold uppercase tracking-wider bg-slate-100 text-slate-400 rounded-full px-2 py-0.5">Soon</span>
       </button>
-      {showTip && (
-        <div className="absolute bottom-full right-0 mb-2 z-10 bg-white border border-slate-200 rounded-xl shadow-md px-3 py-2 text-xs text-slate-500 whitespace-nowrap">
-          Export to .docx / .pdf — planned for a future sprint
-        </div>
-      )}
-    </div>
+      {open && <ResumePreviewModal resume={resume} onClose={() => setOpen(false)} />}
+    </>
   );
 }
 
 // ─── Main page ────────────────────────────────────────────────────────────────
 
-export default function ResumeDisplay( {onPrevious, onComplete, resumeId: resumeIdProp} : {onPrevious?: () => void, onComplete?: () => void, resumeId?: number | null}) {
+export default function ResumeDisplay( {onPrevious, onComplete, resumeId: resumeIdProp, githubUsername = "" , userEmail = ""} : {onPrevious?: () => void, onComplete?: () => void, resumeId?: number | null, githubUsername?: string, userEmail?: string}) {
   const parsedId = resumeIdProp ?? null;
 
-  const [resume, setResume] = useState<Resume>(mockResume);
+  const [resume, setResume] = useState<Resume>({...mockResume, github_username: githubUsername || mockResume.github_username, user_email: userEmail || mockResume.user_email});
   const [loading, setLoading] = useState(parsedId !== null);
     const [error,   setError]   = useState<string | null>(null);
     const [saving,  setSaving]  = useState(false);
   
     useEffect(() => {
       if (parsedId === null) return;
-      fetchResume(parsedId.toString())
+      fetchResume(parsedId.toString(), githubUsername, userEmail)
         .then(r  => { setResume(r); setLoading(false); })
         .catch(e => { setError(e.message); setLoading(false); });
-    }, [parsedId]);
+    }, [parsedId, githubUsername, userEmail]);
   
     // Merges a partial update into state and immediately PUTs to the backend.
     // In mock mode (no parsedId) the PUT is skipped — changes are session-only.
@@ -651,13 +658,13 @@ export default function ResumeDisplay( {onPrevious, onComplete, resumeId: resume
           <p className="text-xs font-semibold uppercase tracking-widest text-indigo-500 mb-1">Resume Display &amp; Editor</p>
           <div className="flex items-center justify-between flex-wrap gap-3">
             <h1 className="text-3xl font-bold text-slate-800">Your generated resume.</h1>
-            <DownloadButton />
+            <PreviewButton resume={resume} />
           </div>
           {saving && <p className="text-xs text-indigo-400 mt-1">Saving…</p>}
           {error  && <p className="text-xs text-red-400   mt-1">Error: {error}</p>}
         </div>
         <div className="space-y-5">
-          <ContactSection github_username={resume.github_username ?? ""} user_email={resume.user_email ?? ""} onChange={(u, e) => update({github_username: u, user_email: e })} />
+          <ContactSection full_name={resume.full_name ?? ""} github_username={resume.github_username ?? ""} user_email={resume.user_email ?? ""} phone={resume.phone ?? ""} linkedin={resume.linkedin ?? ""} onChange={(fn, u, e, p, l) => update({full_name: fn, github_username: u, user_email: e, phone: p, linkedin: l })} />
           <SummarySection  summary={resume.summary} onChange={s => update({summary: s })} />
           <WorkExperienceSection
             work={resume.work_experience}

--- a/app/frontend/capstone-project-frontend/src/types/resumeTypes.ts
+++ b/app/frontend/capstone-project-frontend/src/types/resumeTypes.ts
@@ -52,6 +52,9 @@ export interface Resume {
     // We should add these fields here and return them from the backend, since they are important pieces of information to display in the resume.
     github_username?: string;
     user_email?: string;
+    phone?: string;
+    linkedin?: string;
+    full_name?: string;
 }
 
 

--- a/app/frontend/capstone-project-frontend/src/utils/resumeExports.ts
+++ b/app/frontend/capstone-project-frontend/src/utils/resumeExports.ts
@@ -1,0 +1,242 @@
+import {
+  Document, Packer, Paragraph, TextRun, AlignmentType,
+  LevelFormat, BorderStyle,
+} from "docx";
+import type { Resume } from "../types/resumeTypes";
+
+// ─── Shared layout constants ───────────────────────────────────────────────────
+
+const CONTENT_WIDTH = 9360; // DXA — US Letter (12240) minus 1" margins each side (1440 × 2)
+const MARGIN        = 864;  // 0.6" margins (a bit tighter for one-page fit)
+const PAGE_W        = 12240;
+const PAGE_H        = 15840;
+
+// ─── DOCX helpers ─────────────────────────────────────────────────────────────
+
+function sectionDivider(): Paragraph {
+  return new Paragraph({
+    border: { bottom: { style: BorderStyle.SINGLE, size: 6, color: "333333", space: 1 } },
+    spacing: { before: 100, after: 60 },
+    children: [],
+  });
+}
+
+function sectionHeading(text: string): Paragraph {
+  return new Paragraph({
+    spacing: { before: 120, after: 40 },
+    children: [new TextRun({ text: text.toUpperCase(), bold: true, size: 22, font: "Arial" })],
+  });
+}
+
+function bullet(text: string): Paragraph {
+  return new Paragraph({
+    numbering: { reference: "resume-bullets", level: 0 },
+    spacing: { before: 0, after: 20 },
+    children: [new TextRun({ text, size: 20, font: "Arial" })],
+  });
+}
+
+function twoColumnLine(left: string, right: string, leftBold = false): Paragraph {
+  return new Paragraph({
+    tabStops: [{ type: "right" as any, position: CONTENT_WIDTH }],
+    spacing: { before: 0, after: 20 },
+    children: [
+      new TextRun({ text: left, bold: leftBold, size: 20, font: "Arial" }),
+      new TextRun({ text: "\t" + right, size: 20, font: "Arial", color: "555555" }),
+    ],
+  });
+}
+
+function subLine(text: string, italic = false): Paragraph {
+  return new Paragraph({
+    spacing: { before: 0, after: 20 },
+    children: [new TextRun({ text, italics: italic, size: 20, font: "Arial", color: "444444" })],
+  });
+}
+
+// ─── Section builders ─────────────────────────────────────────────────────────
+
+function buildContact(r: Resume): Paragraph[] {
+  const contactParts: string[] = [];
+  if (r.user_email)      contactParts.push(r.user_email);
+  if (r.github_username) contactParts.push(`github.com/${r.github_username}`);
+  if (r.phone)           contactParts.push(r.phone);
+  if (r.linkedin)        contactParts.push(r.linkedin);
+
+  return [
+    new Paragraph({
+      alignment: AlignmentType.CENTER,
+      spacing: { before: 0, after: 60 },
+      children: [new TextRun({ text: r.full_name || r.github_username || "Resume", bold: true, size: 36, font: "Arial" })],
+    }),
+    new Paragraph({
+      alignment: AlignmentType.CENTER,
+      spacing: { before: 0, after: 40 },
+      children: [new TextRun({ text: contactParts.join("  |  "), size: 19, font: "Arial", color: "444444" })],
+    }),
+  ];
+}
+
+function buildSummary(summary: string[]): Paragraph[] {
+  if (!summary.length) return [];
+  return [
+    sectionHeading("Summary"),
+    sectionDivider(),
+    ...summary.map(s => bullet(s)),
+  ];
+}
+
+function buildWorkExperience(work: Resume["work_experience"]): Paragraph[] {
+  if (!work.length) return [];
+  const paras: Paragraph[] = [sectionHeading("Work Experience"), sectionDivider()];
+  for (const w of work) {
+    paras.push(twoColumnLine(`${w.role} — ${w.company}`, w.date_range, true));
+    if (w.location) paras.push(subLine(w.location, true));
+    w.description.forEach(d => paras.push(bullet(d)));
+    paras.push(new Paragraph({ spacing: { before: 0, after: 60 }, children: [] }));
+  }
+  return paras;
+}
+
+function buildEducation(education: Resume["education"]): Paragraph[] {
+  if (!education.length) return [];
+  const paras: Paragraph[] = [sectionHeading("Education"), sectionDivider()];
+  for (const e of education) {
+    paras.push(twoColumnLine(e.institution, e.date_range, true));
+    const degreeStr = [e.degree, e.major ? `Major in ${e.major}` : "", e.minor ? `Minor in ${e.minor}` : ""].filter(Boolean).join(" · ");
+    paras.push(subLine(degreeStr));
+    if (e.notes) paras.push(subLine(e.notes, true));
+    paras.push(new Paragraph({ spacing: { before: 0, after: 60 }, children: [] }));
+  }
+  return paras;
+}
+
+function buildProjects(projects: Resume["projects"]): Paragraph[] {
+  if (!projects.length) return [];
+  const paras: Paragraph[] = [sectionHeading("Projects"), sectionDivider()];
+  for (const p of projects) {
+    paras.push(twoColumnLine(p.name, p.date_range, true));
+    if (p.frameworks.length) paras.push(subLine(`Technologies: ${p.frameworks.join(", ")}`));
+    paras.push(bullet(p.collaboration));
+    paras.push(new Paragraph({ spacing: { before: 0, after: 60 }, children: [] }));
+  }
+  return paras;
+}
+
+function buildAwards(awards: Resume["awards"]): Paragraph[] {
+  if (!awards.length) return [];
+  const paras: Paragraph[] = [sectionHeading("Awards & Honours"), sectionDivider()];
+  for (const a of awards) {
+    paras.push(twoColumnLine(`${a.title} — ${a.issuer}`, a.date, true));
+    a.description.forEach(d => paras.push(bullet(d)));
+    paras.push(new Paragraph({ spacing: { before: 0, after: 60 }, children: [] }));
+  }
+  return paras;
+}
+
+function buildSkills(skills: string[]): Paragraph[] {
+  if (!skills.length) return [];
+  return [
+    sectionHeading("Skills"),
+    sectionDivider(),
+    new Paragraph({
+      spacing: { before: 0, after: 60 },
+      children: [new TextRun({ text: skills.join("  ·  "), size: 20, font: "Arial" })],
+    }),
+  ];
+}
+
+function buildLanguages(languages: Resume["languages"]): Paragraph[] {
+  if (!languages.length) return [];
+  return [
+    sectionHeading("Programming Languages"),
+    sectionDivider(),
+    new Paragraph({
+      spacing: { before: 0, after: 60 },
+      children: [new TextRun({ text: languages.map(l => l.name).join("  ·  "), size: 20, font: "Arial" })],
+    }),
+  ];
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export async function downloadDocx(resume: Resume): Promise<void> {
+  const doc = new Document({
+    numbering: {
+      config: [{
+        reference: "resume-bullets",
+        levels: [{
+          level: 0,
+          format: LevelFormat.BULLET,
+          text: "\u2022",
+          alignment: AlignmentType.LEFT,
+          style: { paragraph: { indent: { left: 360, hanging: 180 } } },
+        }],
+      }],
+    },
+    sections: [{
+      properties: {
+        page: {
+          size: { width: PAGE_W, height: PAGE_H },
+          margin: { top: MARGIN, right: MARGIN, bottom: MARGIN, left: MARGIN },
+        },
+      },
+      children: [
+        ...buildContact(resume),
+        ...buildSummary(resume.summary),
+        ...buildWorkExperience(resume.work_experience),
+        ...buildEducation(resume.education),
+        ...buildProjects(resume.projects),
+        ...buildAwards(resume.awards),
+        ...buildSkills(resume.skills),
+        ...buildLanguages(resume.languages),
+      ],
+    }],
+  });
+  const blob = await Packer.toBlob(doc);
+  triggerDownload(blob, "resume.docx");
+}
+
+export function downloadPdf(previewElement: HTMLElement): void {
+  const LETTER_HEIGHT_PX = 1056;
+  const PADDING = 48; // px on each side
+  const scale = Math.min(1, LETTER_HEIGHT_PX / previewElement.scrollHeight);
+
+  const clone = document.createElement("div");
+  clone.id = "resume-print-target";
+  clone.style.cssText = `
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 816px;
+    background: white;
+    padding: ${PADDING}px;
+    box-sizing: border-box;
+    transform-origin: top left;
+    transform: scale(${scale});
+  `;
+  clone.innerHTML = previewElement.innerHTML;
+  document.body.appendChild(clone);
+
+  const style = document.createElement("style");
+  style.textContent = `
+    @media print {
+      body > * { display: none !important; }
+      #resume-print-target { display: block !important; }
+      @page { margin: 0; size: letter portrait; }
+    }
+  `;
+  document.head.appendChild(style);
+  window.print();
+  document.head.removeChild(style);
+  document.body.removeChild(clone);
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a   = document.createElement("a");
+  a.href    = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## 📝 Description

This PR set up the functionality to download the resume that the user has generated. I created a preview modal so the user can see what their resume is going to look like once exported. Since the display and editing page in the system prioritizes readability for the user, it does not actually reflect the professional resume formatting that we use for the final product. 

Once viewing the preview, the user has the option to download this resume either as a docx file or pdf. Given the time constraint, I opted to just use the print to pdf for the pdf exporting for ease of implementation. The priority was for docx to be functional since that allows the user further editing control. 

In working through this a few bugs and missed implementation pieces came up that I also resolved in this PR. We now allow the user to input their full name so that it can be displayed at the top of the resume instead of the github username. We also now pass the github username and email so that the user is able to see them populated on the resume. The other additions were a phone number and linkedin url so that the user had full options of customizing how a future employer can contact them. 

In order to enforce a single page, I added scaling logic to restrict the length and width. Where this could cause issues is if the user inputs a ton of information, when they go to export it the document will shrink to an illegible size. 

Also note, I am aware of failing tests created by this PR. Given the overall line limitations, the fix for testing will be in the overall testing PR that will follow immediatley after this. 

**Closes:** #532 #533 #534 

---

## 🔧 Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [X] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Testing was not touched within this PR, so functionality can be checked through manual testing. Once an analysis is in the system (preferably generated through the backend since that does not encounter the issue where some of the sections are not created and thus not displayed that we have when run through the front end) view the resume from the dashboard. Add the sections that we do not populate (full name, education, awards, etc) and then press the download button. It should open up the preview window where you can follow the prompt to download as docx and pdf to ensure functionality. Tests have been created on a separate branch which are all passing, and can be viewed to ensure this functionality. 

---

## ✓ Checklist

- [X] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [X] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
